### PR TITLE
Ignore folder already exists errors

### DIFF
--- a/utils/fsUtils.js
+++ b/utils/fsUtils.js
@@ -43,6 +43,7 @@ function ensurePath(path) {
                     errorMessage.includes('folder') 
                     || errorMessage.includes('directory')
                 )
+                || errorMessage.includes('folder')
             ){
                 return;
             }

--- a/utils/fsUtils.js
+++ b/utils/fsUtils.js
@@ -35,10 +35,18 @@ function ensurePath(path) {
             }
         })
         .catch(err => {
+            const errorMessage = err.message.toLowerCase();
             // ignore folder already exists errors
-            if (err.message.includes('folder already exists')) {
+            if (
+                errorMessage.includes('already exists')
+                && (
+                    errorMessage.includes('folder') 
+                    || errorMessage.includes('directory')
+                )
+            ){
                 return;
             }
+
             return Promise.reject(err);
         });
 }


### PR DESCRIPTION
We detected that when a folder exists, the error message is different from the one being handled.
The error we received was 'Directory {path} already exists'