### PR TITLE
moved `netinfo` to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   ],
   "typings": "./index.d.ts",
   "dependencies": {
-    "@react-native-community/netinfo": "^2.0.3",
     "crypto-js": "3.1.9-1",
     "lodash": "^4.17.10",
     "prop-types": "15.5.10",
@@ -65,5 +64,8 @@
     "react-native": "^0.48.3",
     "react-test-renderer": "^15.6.1",
     "regenerator-runtime": "^0.11.0"
+  },
+  "peerDependencies": {
+    "@react-native-community/netinfo": ""^4.0.0",
   }
 }


### PR DESCRIPTION
external libraries especially ones integrating with react-native should be peer Dependecies