### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^4.17.10",
     "prop-types": "15.5.10",
     "react-native-clcasher": "1.0.0",
-    "rn-fetch-blob": "^0.10.11",
+    "rn-fetch-blob": "0.10.15",
     "url-parse": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Using rn-fetch-blob > 0.10.15 breaks unless you run RN 0.60+