### PR TITLE
Rename deprecated methods to suppress warnings (for now)

### DIFF
--- a/CachedImage.js
+++ b/CachedImage.js
@@ -77,7 +77,7 @@ class CachedImage extends React.Component {
         this.renderLoader = this.renderLoader.bind(this);
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this._isMounted = true;
         NetInfo.isConnected.addEventListener('connectionChange', this.handleConnectivityChange);
         // initial
@@ -96,7 +96,7 @@ class CachedImage extends React.Component {
         NetInfo.isConnected.removeEventListener('connectionChange', this.handleConnectivityChange);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         if (!_.isEqual(this.props.source, nextProps.source)) {
             this.processSource(nextProps.source);
         }

--- a/CachedImageExample/index.js
+++ b/CachedImageExample/index.js
@@ -87,7 +87,7 @@ class CachedImageExample extends React.Component {
 
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         defaultImageCacheManager.downloadAndCacheUrl(image1);
     }
 

--- a/ImageCacheProvider.js
+++ b/ImageCacheProvider.js
@@ -54,11 +54,11 @@ class ImageCacheProvider extends React.Component {
         };
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.preloadImages(this.props.urlsToPreload);
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
         // reset imageCacheManager in case any option changed
         this.imageCacheManager = null;
         // preload new images if needed


### PR DESCRIPTION
Not the real fix, but should buy us a few more months.