### PR TITLE
fix: Change @react-native-community/net-info to a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This package is greatly inspired by [@jayesbe](https://github.com/jayesbe)'s ama
 
 ## Installation
 
-    npm install react-native-cached-image --save
+    npm install react-native-cached-image @react-native-community/netinfo rn-fetch-blob --save
     - or -
-    yarn add react-native-cached-image
+    yarn add react-native-cached-image @react-native-community/netinfo rn-fetch-blob
 
 We use [`rn-fetch-blob`](https://github.com/joltup/rn-fetch-blob#installation) to handle file system access in this package and it requires an extra step during the installation.  
 

--- a/package.json
+++ b/package.json
@@ -51,11 +51,11 @@
     "lodash": "^4.17.10",
     "prop-types": "15.5.10",
     "react-native-clcasher": "1.0.0",
-    "rn-fetch-blob": "^0.11.2",
     "url-parse": "^1.4.1"
   },
   "peerDependencies": {
-    "@react-native-community/netinfo": "^4.1.3",
+    "@react-native-community/netinfo": "^4.6.0",
+    "rn-fetch-blob": "^0.11.2"
   },
   "devDependencies": {
     "babel-jest": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -47,13 +47,15 @@
   ],
   "typings": "./index.d.ts",
   "dependencies": {
-    "@react-native-community/netinfo": "^4.1.3",
     "crypto-js": "3.1.9-1",
     "lodash": "^4.17.10",
     "prop-types": "15.5.10",
     "react-native-clcasher": "1.0.0",
     "rn-fetch-blob": "^0.11.2",
     "url-parse": "^1.4.1"
+  },
+  "peerDependencies" {
+    "@react-native-community/netinfo": "^4.1.3",
   },
   "devDependencies": {
     "babel-jest": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rn-fetch-blob": "^0.11.2",
     "url-parse": "^1.4.1"
   },
-  "peerDependencies" {
+  "peerDependencies": {
     "@react-native-community/netinfo": "^4.1.3",
   },
   "devDependencies": {


### PR DESCRIPTION
To correctly support auto linking and allow app authors to use different versions of the NetInfo library, you need to define it as a peer dependency.

See here for details:

https://github.com/react-native-community/react-native-netinfo/issues/234#issuecomment-549121135